### PR TITLE
Remove the .gov.sg banner from the website

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,6 +9,8 @@ markdown: kramdown
 remote_theme: isomerpages/isomerpages-template
 safe: false
 
+is_government: false
+
 plugins:
   - jekyll-feed
   - jekyll-assets


### PR DESCRIPTION
As m3.sg is not a .gov.sg site, we need to remove the Singapore Government banner.